### PR TITLE
fix systemd unit typo

### DIFF
--- a/systemd/mprisence-local.service
+++ b/systemd/mprisence-local.service
@@ -2,7 +2,7 @@
 Description=A Discord Rich Presence client for MPRIS-compatible media players with support for album cover
 
 [Service]
-type=simple
+Type=simple
 ExecStart=/usr/local/bin/mprisence
 Restart=on-failure
 RestartSec=3

--- a/systemd/mprisence.service
+++ b/systemd/mprisence.service
@@ -2,7 +2,7 @@
 Description=A Discord Rich Presence client for MPRIS-compatible media players with support for album cover
 
 [Service]
-type=simple
+Type=simple
 ExecStart=/usr/bin/mprisence
 Restart=on-failure
 RestartSec=3


### PR DESCRIPTION
Current systemd unit logs a warning:
`/usr/lib/systemd/user/mprisence.service:5: Unknown key 'type' in section [Service], ignoring.`

This patch changes "type" to "Type" in the unit file to fix this warning
