### PR TITLE
Fix: D-Bus timeout error while updating rich presence

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -135,13 +135,15 @@ impl Mprisence {
         })?;
 
         for player_result in players {
-            let player = match player_result {
+            let mut player = match player_result {
                 Ok(p) => p,
                 Err(e) => {
                     warn!("Failed to get player: {}", e);
                     continue;
                 }
             };
+
+            player.set_dbus_timeout_ms(5000);
 
             let id = PlayerIdentifier::from(&player);
 


### PR DESCRIPTION
### Problem

As reported in #41, the application could panic with a `TransportError(D-Bus error: Did not receive a reply...)` when attempting to get the playback status from certain players (like musikcube in the issue). This was caused by using `.unwrap()` on the result of `player.get_playback_status()`.

Additionally, during investigation, excessive "Position jumped forward" debug logs were observed, indicating the jump detection logic was too sensitive to normal D-Bus latency.

### Testing

- Ran locally with musikcube.
- Verified the application no longer panics when playback status retrieval encounters D-Bus issues (simulated or real).
- Observed significantly fewer "Position jumped forward" logs during normal playback.