### PR TITLE
add fooyin to default config

### DIFF
--- a/config/config.default.toml
+++ b/config/config.default.toml
@@ -95,6 +95,10 @@ icon = "https://dashboard.snapcraft.io/site_media/appmedia/2022/09/io.bassi.Ambe
 app_id = "1125077752756834314"
 icon = "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/SMPlayer_icon.svg/1200px-SMPlayer_icon.svg.png"
 
+[player.fooyin]
+app_id = "1396689706246209606"
+icon = "https://dl.flathub.org/media/org/fooyin/fooyin/ef334d703743511632d5c616bea80c43/icons/128x128@2/org.fooyin.fooyin.png"
+
 [player.spotify]
 ignore = true
 


### PR DESCRIPTION
This pull request updates the `config/config.default.toml` file to add a new player configuration and its associated metadata. For issue #44.

### Added player configuration:
* Added a new player entry for `fooyin` with its `app_id` and `icon` URL.

```toml
[player.fooyin]
app_id = "1396689706246209606"
icon = "https://dl.flathub.org/media/org/fooyin/fooyin/ef334d703743511632d5c616bea80c43/icons/128x128@2/org.fooyin.fooyin.png"
```

<img width="267" height="105" alt="image" src="https://github.com/user-attachments/assets/3b954a67-c003-425f-b2bf-c1c14fac494b" />