### PR TITLE
add Supersonic and Feishin + local/private url check for cover art retrieval

### DIFF
--- a/config/config.default.toml
+++ b/config/config.default.toml
@@ -99,6 +99,14 @@ icon = "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/SMPlayer_icon.
 app_id = "1396689706246209606"
 icon = "https://dl.flathub.org/media/org/fooyin/fooyin/ef334d703743511632d5c616bea80c43/icons/128x128@2/org.fooyin.fooyin.png"
 
+[player.supersonic]
+app_id = "1404479711106568202"
+icon = "https://github.com/dweymouth/supersonic/blob/main/res/appicon-256.png?raw=true"
+
+[player.feishin]
+app_id = "1404479248428826645"
+icon = "https://github.com/jeffvli/feishin/blob/development/assets/icons/256x256.png?raw=true"
+
 [player.spotify]
 ignore = true
 


### PR DESCRIPTION
**Configuration updates:**
* Added entries for the `supersonic` and `feishin` players, including their `app_id` and icon URLs in `config/config.default.toml`. #47 

**Cover art retrieval improvements:**
* Added a new method `is_local_or_private_url` to detect local or private URLs using the `url` crate, improving safety when handling direct URLs. [[1]](diffhunk://#diff-7272d583efa2bc245ec8c9ff9246d315ac8baad1a21927f9ddeca1f8fd983fc6R5) [[2]](diffhunk://#diff-7272d583efa2bc245ec8c9ff9246d315ac8baad1a21927f9ddeca1f8fd983fc6R66-R91)
* Updated the cover art retrieval flow to avoid using local/private URLs directly. Instead, the code attempts to fetch the image bytes and pass them to providers that can upload or process them, rather than exposing internal URLs.