### PR TITLE
Fixed not decoding artUrl

### DIFF
--- a/src/cover/mod.rs
+++ b/src/cover/mod.rs
@@ -139,7 +139,10 @@ impl CoverManager {
         // 3. Try to find local cover art if we have a file path
         if let Some(path) = metadata_source.url().and_then(|url| {
             if url.starts_with("file://") {
-                Some(PathBuf::from(&url[7..]))
+                match urlencoding::decode(&url[7..]) {
+                    Ok(dec) => Some(PathBuf::from(dec.into_owned())),
+                    Err(_) => return None,
+                }
             } else {
                 None
             }

--- a/src/cover/sources.rs
+++ b/src/cover/sources.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use walkdir::WalkDir;
 use std::collections::HashSet;
-
 use crate::cover::error::CoverArtError;
 
 #[derive(Debug, Clone)]
@@ -32,7 +31,10 @@ impl ArtSource {
         }
 
         let path = if url.starts_with("file://") {
-            url[7..].parse().ok()
+            match urlencoding::decode(&url[7..]) {
+                Ok(dec) => dec.parse().ok(),
+                Err(_) => return None,
+            }
         } else {
             url.parse().ok()
         };


### PR DESCRIPTION
This fixes reading cover art files that contain special characters, most notably spaces, as `Path`s don't support URL encoding